### PR TITLE
refactor: create datastore by factory method

### DIFF
--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -23,14 +23,20 @@ import (
 	"log"
 
 	"github.com/CanonicalLtd/iot-identity/config"
-	"github.com/CanonicalLtd/iot-identity/datastore/memory"
+	"github.com/CanonicalLtd/iot-identity/datastore"
 	"github.com/CanonicalLtd/iot-identity/service"
 	"github.com/CanonicalLtd/iot-identity/web"
 )
 
 func main() {
 	settings := config.ParseArgs()
-	db := memory.NewStore()
+
+	// Create the data store
+	db, err := datastore.New(settings)
+	if err != nil {
+		log.Fatal("Error creating datastore", err)
+	}
+
 	srv := service.NewIdentityService(settings, db)
 
 	// Start the web service

--- a/datastore/common/common.go
+++ b/datastore/common/common.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * This file is part of the IoT Identity Service
+ * Copyright 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License version 3, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"github.com/CanonicalLtd/iot-identity/domain"
+	"github.com/segmentio/ksuid"
+)
+
+// OrganizationNewRequest is the request to create a new organization
+type OrganizationNewRequest struct {
+	Name        string
+	CountryName string
+	ServerKey   []byte
+	ServerCert  []byte
+}
+
+// DeviceNewRequest is the request to create a new device
+type DeviceNewRequest struct {
+	ID             string
+	OrganizationID string
+	Brand          string
+	Model          string
+	SerialNumber   string
+	Credentials    domain.Credentials
+}
+
+// DeviceEnrollRequest is the request to enroll a device.
+// The details come from the model and serial assertion
+type DeviceEnrollRequest struct {
+	Brand        string
+	Model        string
+	SerialNumber string
+	DeviceKey    string
+	StoreID      string
+}
+
+// GenerateID generates a unique ID
+func GenerateID() string {
+	id := ksuid.New()
+	return id.String()
+}

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -37,7 +37,8 @@ type DataStore interface {
 	DeviceEnroll(device common.DeviceEnrollRequest) (*domain.Enrollment, error)
 }
 
-// Factory method to create data store based on driver selected in settings.
+// New is the factory method to create data store based
+// on driver selected in settings.
 func New(settings *config.Settings) (DataStore, error) {
 	if settings.Driver == "memory" {
 		db := memory.NewStore()

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -20,50 +20,29 @@
 package datastore
 
 import (
+	"errors"
+	"github.com/CanonicalLtd/iot-identity/config"
+	"github.com/CanonicalLtd/iot-identity/datastore/common"
+	"github.com/CanonicalLtd/iot-identity/datastore/memory"
 	"github.com/CanonicalLtd/iot-identity/domain"
-	"github.com/segmentio/ksuid"
 )
 
 // DataStore is the interfaces for the data repository
 type DataStore interface {
-	OrganizationNew(organization OrganizationNewRequest) (string, error)
+	OrganizationNew(organization common.OrganizationNewRequest) (string, error)
 	OrganizationGet(id string) (*domain.Organization, error)
 	OrganizationGetByName(name string) (*domain.Organization, error)
-	DeviceNew(device DeviceNewRequest) (string, error)
+	DeviceNew(device common.DeviceNewRequest) (string, error)
 	DeviceGet(brand, model, serial string) (*domain.Enrollment, error)
-	DeviceEnroll(device DeviceEnrollRequest) (*domain.Enrollment, error)
+	DeviceEnroll(device common.DeviceEnrollRequest) (*domain.Enrollment, error)
 }
 
-// OrganizationNewRequest is the request to create a new organization
-type OrganizationNewRequest struct {
-	Name        string
-	CountryName string
-	ServerKey   []byte
-	ServerCert  []byte
-}
+// Factory method to create data store based on driver selected in settings.
+func New(settings *config.Settings) (DataStore, error) {
+	if settings.Driver == "memory" {
+		db := memory.NewStore()
+		return db, nil
+	}
 
-// DeviceNewRequest is the request to create a new device
-type DeviceNewRequest struct {
-	ID             string
-	OrganizationID string
-	Brand          string
-	Model          string
-	SerialNumber   string
-	Credentials    domain.Credentials
-}
-
-// DeviceEnrollRequest is the request to enroll a device.
-// The details come from the model and serial assertion
-type DeviceEnrollRequest struct {
-	Brand        string
-	Model        string
-	SerialNumber string
-	DeviceKey    string
-	StoreID      string
-}
-
-// GenerateID generates a unique ID
-func GenerateID() string {
-	id := ksuid.New()
-	return id.String()
+	return nil, errors.New("Unknown DataStore driver supplied")
 }

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * This file is part of the IoT Identity Service
+ * Copyright 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License version 3, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package datastore
+
+import (
+	"testing"
+
+	"github.com/CanonicalLtd/iot-identity/config"
+)
+
+func TestDatastore_New(t *testing.T) {
+	settings := config.Settings{Driver: "memory"}
+
+	db, err := New(&settings)
+	if err != nil {
+		t.Errorf("datastore.New() error = %v", err)
+	}
+
+	if db == nil {
+		t.Errorf("datastore.New() error = memory not created")
+	}
+}
+
+func TestDatastore_NewNegative(t *testing.T) {
+	settings := config.Settings{Driver: "garbage"}
+
+	_, err := New(&settings)
+	if err == nil {
+		t.Errorf("datastore.New() error = no err for incorrect driver")
+	}
+}

--- a/datastore/memory/memory.go
+++ b/datastore/memory/memory.go
@@ -21,7 +21,7 @@ package memory
 
 import (
 	"fmt"
-	"github.com/CanonicalLtd/iot-identity/datastore"
+	"github.com/CanonicalLtd/iot-identity/datastore/common"
 	"github.com/CanonicalLtd/iot-identity/domain"
 )
 
@@ -64,7 +64,7 @@ func NewStore() *Store {
 }
 
 // OrganizationNew creates a new organization
-func (mem *Store) OrganizationNew(organization datastore.OrganizationNewRequest) (string, error) {
+func (mem *Store) OrganizationNew(organization common.OrganizationNewRequest) (string, error) {
 	// Validate the organization
 
 	if len(organization.Name) == 0 || len(organization.ServerKey) == 0 || len(organization.ServerCert) == 0 {
@@ -79,7 +79,7 @@ func (mem *Store) OrganizationNew(organization datastore.OrganizationNewRequest)
 	}
 
 	// Store it
-	id := datastore.GenerateID()
+	id := common.GenerateID()
 	o := domain.Organization{
 		ID:       id,
 		Name:     organization.Name,
@@ -111,7 +111,7 @@ func (mem *Store) OrganizationGet(id string) (*domain.Organization, error) {
 }
 
 // DeviceNew creates a new device registration
-func (mem *Store) DeviceNew(device datastore.DeviceNewRequest) (string, error) {
+func (mem *Store) DeviceNew(device common.DeviceNewRequest) (string, error) {
 	// Validate
 	if len(device.Brand) == 0 || len(device.Model) == 0 || len(device.SerialNumber) == 0 || len(device.OrganizationID) == 0 {
 		return "", fmt.Errorf("the provided device details are incomplete")
@@ -133,7 +133,7 @@ func (mem *Store) DeviceNew(device datastore.DeviceNewRequest) (string, error) {
 	// Store it
 	deviceID := device.ID
 	if len(deviceID) == 0 {
-		deviceID = datastore.GenerateID()
+		deviceID = common.GenerateID()
 	}
 
 	d := domain.Device{
@@ -163,7 +163,7 @@ func (mem *Store) DeviceGet(brand, model, serial string) (*domain.Enrollment, er
 }
 
 // DeviceEnroll enrols a device with the IoT service
-func (mem *Store) DeviceEnroll(device datastore.DeviceEnrollRequest) (*domain.Enrollment, error) {
+func (mem *Store) DeviceEnroll(device common.DeviceEnrollRequest) (*domain.Enrollment, error) {
 	// Get the registered device
 	reg, err := mem.DeviceGet(device.Brand, device.Model, device.SerialNumber)
 	if err != nil {

--- a/datastore/memory/memory_test.go
+++ b/datastore/memory/memory_test.go
@@ -23,26 +23,26 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/CanonicalLtd/iot-identity/datastore"
+	"github.com/CanonicalLtd/iot-identity/datastore/common"
 	"github.com/CanonicalLtd/iot-identity/domain"
 )
 
 func TestStore_OrganizationNew(t *testing.T) {
-	req1 := datastore.OrganizationNewRequest{
+	req1 := common.OrganizationNewRequest{
 		Name:        "Example Ltd",
 		CountryName: "United Kingdom",
 		ServerKey:   []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA4LzuMogDv9It"),
 		ServerCert:  []byte("-----BEGIN CERTIFICATE-----\nMIICYzCCAUsCAQAwHjEcMBoGA1UECgwT"),
 	}
-	req2 := datastore.OrganizationNewRequest{}
-	req3 := datastore.OrganizationNewRequest{
+	req2 := common.OrganizationNewRequest{}
+	req3 := common.OrganizationNewRequest{
 		Name:        "Example Inc",
 		CountryName: "United Kingdom",
 		ServerKey:   []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA4LzuMogDv9It"),
 		ServerCert:  []byte("-----BEGIN CERTIFICATE-----\nMIICYzCCAUsCAQAwHjEcMBoGA1UECgwT"),
 	}
 	type args struct {
-		organization datastore.OrganizationNewRequest
+		organization common.OrganizationNewRequest
 	}
 	tests := []struct {
 		name    string
@@ -75,20 +75,20 @@ func TestStore_OrganizationNew(t *testing.T) {
 }
 
 func TestStore_DeviceNew(t *testing.T) {
-	req1 := datastore.DeviceNewRequest{
+	req1 := common.DeviceNewRequest{
 		OrganizationID: "abc",
 		Brand:          "example",
 		Model:          "drone-1000",
 		SerialNumber:   "b222",
 	}
-	req2 := datastore.DeviceNewRequest{}
-	req3 := datastore.DeviceNewRequest{
+	req2 := common.DeviceNewRequest{}
+	req3 := common.DeviceNewRequest{
 		OrganizationID: "abc",
 		Brand:          "example",
 		Model:          "drone-1000",
 		SerialNumber:   "DR1000A111",
 	}
-	req4 := datastore.DeviceNewRequest{
+	req4 := common.DeviceNewRequest{
 		OrganizationID: "invalid",
 		Brand:          "example",
 		Model:          "drone-1000",
@@ -96,7 +96,7 @@ func TestStore_DeviceNew(t *testing.T) {
 	}
 
 	type args struct {
-		device datastore.DeviceNewRequest
+		device common.DeviceNewRequest
 	}
 	tests := []struct {
 		name    string
@@ -130,14 +130,14 @@ func TestStore_DeviceNew(t *testing.T) {
 }
 
 func TestStore_DeviceEnroll(t *testing.T) {
-	req1 := datastore.DeviceEnrollRequest{
+	req1 := common.DeviceEnrollRequest{
 		Brand:        "example",
 		Model:        "drone-1000",
 		SerialNumber: "DR1000A111",
 		StoreID:      "example-store",
 		DeviceKey:    "-----BEGIN GPG PUBLIC KEY-----\nMIIEpAIBAAKCAQ",
 	}
-	req2 := datastore.DeviceEnrollRequest{
+	req2 := common.DeviceEnrollRequest{
 		Brand:        "invalid",
 		Model:        "drone-1000",
 		SerialNumber: "DR1000A111",
@@ -156,7 +156,7 @@ func TestStore_DeviceEnroll(t *testing.T) {
 	}
 
 	type args struct {
-		device datastore.DeviceEnrollRequest
+		device common.DeviceEnrollRequest
 	}
 	tests := []struct {
 		name    string

--- a/datastore/postgres/postgres.go
+++ b/datastore/postgres/postgres.go
@@ -23,7 +23,7 @@ import (
 	"database/sql"
 
 	"github.com/CanonicalLtd/iot-identity/config"
-	"github.com/CanonicalLtd/iot-identity/datastore"
+	"github.com/CanonicalLtd/iot-identity/datastore/common"
 	"github.com/CanonicalLtd/iot-identity/domain"
 	_ "github.com/lib/pq" // postgresql driver
 )
@@ -47,7 +47,7 @@ func (pg *Store) createTables() error {
 }
 
 // OrganizationNew creates a new organization
-func (pg *Store) OrganizationNew(organization datastore.OrganizationNewRequest) (string, error) {
+func (pg *Store) OrganizationNew(organization common.OrganizationNewRequest) (string, error) {
 	panic("implement me")
 }
 
@@ -62,7 +62,7 @@ func (pg *Store) OrganizationGetByName(name string) (*domain.Organization, error
 }
 
 // DeviceNew creates a new device registration
-func (pg *Store) DeviceNew(device datastore.DeviceNewRequest) (string, error) {
+func (pg *Store) DeviceNew(device common.DeviceNewRequest) (string, error) {
 	panic("implement me")
 }
 
@@ -72,6 +72,6 @@ func (pg *Store) DeviceGet(brand, model, serial string) (*domain.Enrollment, err
 }
 
 // DeviceEnroll enrols a device with the IoT service
-func (pg *Store) DeviceEnroll(device datastore.DeviceEnrollRequest) (*domain.Enrollment, error) {
+func (pg *Store) DeviceEnroll(device common.DeviceEnrollRequest) (*domain.Enrollment, error) {
 	panic("implement me")
 }

--- a/service/service.go
+++ b/service/service.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/CanonicalLtd/iot-identity/config"
 	"github.com/CanonicalLtd/iot-identity/datastore"
+	"github.com/CanonicalLtd/iot-identity/datastore/common"
 	"github.com/CanonicalLtd/iot-identity/domain"
 	"github.com/CanonicalLtd/iot-identity/service/cert"
 	"github.com/snapcore/snapd/asserts"
@@ -70,7 +71,7 @@ func (id IdentityService) RegisterOrganization(req *RegisterOrganizationRequest)
 	}
 
 	// Create registration
-	o := datastore.OrganizationNewRequest{
+	o := common.OrganizationNewRequest{
 		Name:        req.Name,
 		CountryName: req.CountryName,
 		ServerKey:   serverPEM,
@@ -108,14 +109,14 @@ func (id IdentityService) RegisterDevice(req *RegisterDeviceRequest) (string, er
 	}
 
 	// Create a signed certificate
-	deviceID := datastore.GenerateID()
+	deviceID := common.GenerateID()
 	keyPEM, certPEM, err := cert.CreateClientCert(org, id.Settings.RootCertsDir, deviceID)
 	if err != nil {
 		return "", err
 	}
 
 	// Create registration
-	d := datastore.DeviceNewRequest{
+	d := common.DeviceNewRequest{
 		ID:             deviceID,
 		OrganizationID: req.OrganizationID,
 		Brand:          req.Brand,
@@ -149,7 +150,7 @@ func (id IdentityService) EnrollDevice(req *EnrollDeviceRequest) (*domain.Enroll
 	}
 
 	// Create the enrollment request
-	enroll := datastore.DeviceEnrollRequest{
+	enroll := common.DeviceEnrollRequest{
 		Brand:        req.Model.Header("brand-id").(string),
 		Model:        req.Model.Header("model").(string),
 		SerialNumber: req.Serial.Header("serial").(string),
@@ -163,7 +164,7 @@ func (id IdentityService) EnrollDevice(req *EnrollDeviceRequest) (*domain.Enroll
 }
 
 // Enroll connects an IoT device with the service
-func (id IdentityService) enroll(enroll *datastore.DeviceEnrollRequest) (*domain.Enrollment, error) {
+func (id IdentityService) enroll(enroll *common.DeviceEnrollRequest) (*domain.Enrollment, error) {
 	// Get the registration for the device
 	dev, err := id.DB.DeviceGet(enroll.Brand, enroll.Model, enroll.SerialNumber)
 	if err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/CanonicalLtd/iot-identity/config"
 	"github.com/CanonicalLtd/iot-identity/datastore"
-	"github.com/CanonicalLtd/iot-identity/datastore/memory"
+	"github.com/CanonicalLtd/iot-identity/datastore/common"
 )
 
 const model1 = `type: model
@@ -132,7 +132,11 @@ const ignoreError1 = "the device `canonical/canonical/d75f7300-abbf-4c11-bf0a-8b
 func TestIdentityService_RegisterOrganization(t *testing.T) {
 	settings := config.ParseArgs()
 	settings.RootCertsDir = "../datastore/test_data"
-	db := memory.NewStore()
+	settings.Driver = "memory"
+	db, err := datastore.New(settings)
+	if err != nil {
+		t.Error("datastore.New() = DataStore not created")
+	}
 	req1 := RegisterOrganizationRequest{
 		Name:        "Example PLC",
 		CountryName: "United Kingdom",
@@ -174,7 +178,11 @@ func TestIdentityService_RegisterOrganization(t *testing.T) {
 
 func TestIdentityService_RegisterDevice(t *testing.T) {
 	settings := &config.Settings{RootCertsDir: "../datastore/test_data"}
-	db := memory.NewStore()
+	settings.Driver = "memory"
+	db, err := datastore.New(settings)
+	if err != nil {
+		t.Error("datastore.New() = DataStore not created")
+	}
 	req1 := RegisterDeviceRequest{
 		OrganizationID: "abc",
 		Brand:          "example",
@@ -232,29 +240,33 @@ func TestIdentityService_RegisterDevice(t *testing.T) {
 
 func TestIdentityService_Enroll(t *testing.T) {
 	settings := &config.Settings{RootCertsDir: "../datastore/test_data"}
-	db := memory.NewStore()
-	req1 := datastore.DeviceEnrollRequest{
+	settings.Driver = "memory"
+	db, err := datastore.New(settings)
+	if err != nil {
+		t.Error("datastore.New() = DataStore not created")
+	}
+	req1 := common.DeviceEnrollRequest{
 		Brand:        "example",
 		Model:        "drone-1000",
 		SerialNumber: "DR1000A111",
 		StoreID:      "example-store",
 		DeviceKey:    "AAAAAAAA",
 	}
-	req2 := datastore.DeviceEnrollRequest{
+	req2 := common.DeviceEnrollRequest{
 		Brand:        "invalid",
 		Model:        "drone-1000",
 		SerialNumber: "DR1000A111",
 		StoreID:      "example-store",
 		DeviceKey:    "-----BEGIN GPG PUBLIC KEY-----\nMIIEpAIBAAKCAQ",
 	}
-	req3 := datastore.DeviceEnrollRequest{
+	req3 := common.DeviceEnrollRequest{
 		Brand:        "example",
 		Model:        "drone-1000",
 		SerialNumber: "DR1000B222",
 		StoreID:      "example-store",
 		DeviceKey:    "-----BEGIN GPG PUBLIC KEY-----\nMIIEpAIBAAKCAQ",
 	}
-	req4 := datastore.DeviceEnrollRequest{
+	req4 := common.DeviceEnrollRequest{
 		Brand:        "",
 		Model:        "drone-1000",
 		SerialNumber: "DR1000B222",
@@ -263,7 +275,7 @@ func TestIdentityService_Enroll(t *testing.T) {
 	}
 
 	type args struct {
-		req datastore.DeviceEnrollRequest
+		req common.DeviceEnrollRequest
 	}
 	tests := []struct {
 		name    string
@@ -298,7 +310,11 @@ func TestIdentityService_Enroll(t *testing.T) {
 
 func TestIdentityService_EnrollDevice(t *testing.T) {
 	settings := &config.Settings{RootCertsDir: "../datastore/test_data"}
-	db := memory.NewStore()
+	settings.Driver = "memory"
+	db, err := datastore.New(settings)
+	if err != nil {
+		t.Error("datastore.New() = DataStore not created")
+	}
 
 	type args struct {
 		model  string


### PR DESCRIPTION
This commit refactores datastore package in a way that it introduces factory method so that the concrete instances can be created w/o the need to modify main.go. The concrete instance is now created based on the settings.Driver field.

Example:

```
        db, err := datastore.New(settings)
        err != nil {
                // DataStore not created at all
        }

        // At this point db can be used as DataStore
```