### PR TITLE
Do not require device_data when enrolling

### DIFF
--- a/datastore/postgres/device_sql.go
+++ b/datastore/postgres/device_sql.go
@@ -62,7 +62,7 @@ where device_id=$1`
 
 const enrollDeviceSQL = `
 update device
-set store_id=$4, device_key=$5, status=$6, device_data=$7
+set store_id=$4, device_key=$5, status=$6
 where brand=$1 and model=$2 and serial_number=$3
 `
 


### PR DESCRIPTION
Do not require device_data in the SQL update when a device enrolls, as
that is not part of the data returned by the device. Previously the
status was not changing to "Enrolled" because of this.